### PR TITLE
Cambiato la lingua nella DeleteMapping del Controller in italiano

### DIFF
--- a/src/main/java/com/example/ArchivioLibri/controllers/BooksController.java
+++ b/src/main/java/com/example/ArchivioLibri/controllers/BooksController.java
@@ -61,7 +61,7 @@ public class BooksController {
     @DeleteMapping("/{isbn}")
     public ResponseEntity<String> deleteByIsbn(@PathVariable String isbn) {
         booksService.deleteById(isbn);
-        return new ResponseEntity<>("Book deleted from list", HttpStatus.OK);
+        return new ResponseEntity<>("Libro eliminato", HttpStatus.OK);
     }
 
 


### PR DESCRIPTION
Ho cambiato la lingua nel messaggio di avvenuta eliminazione di un libro tramite ISBN nella DeleteMapping del Controller in italiano, la logica di presentazione è rimasta invariata